### PR TITLE
Exclude unnecessary files

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "module": "dist/tldts.esm.min.js",
   "types": "dist/tldts.d.ts",
   "files": [
-    "dist",
+    "dist"
   ],
   "license": "MIT",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
   "types": "dist/tldts.d.ts",
   "files": [
     "dist",
-    "lib",
-    "tldts.ts",
-    "tldts-experimental.ts"
   ],
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
Hello,

Since all the main browser/Node.js are pointing to a file inside `dist` folder, I think that the rest of files inside `files` field can be removed in order to reduce the package size.