### PR TITLE
Release v5.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 *not released*
 
-- update public suffix ruleset
-- fix source maps
-- make sure tslib does not appear in build artifacts
+### 5.3.2
+
+*2019-07-26*
+
+- update public suffix ruleset [#207](https://github.com/remusao/tldts/pull/207)
+- fix source maps [#207](https://github.com/remusao/tldts/pull/207)
+- make sure tslib does not appear in build artifacts [#207](https://github.com/remusao/tldts/pull/207)
 
 ### 5.3.1
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "5.3.1"
+  "version": "5.3.2"
 }

--- a/packages/tldts-core/package.json
+++ b/packages/tldts-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tldts-core",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "tldts core primitives (internal module)",
   "author": "Rémi Berson",
   "contributors": [

--- a/packages/tldts-experimental/package.json
+++ b/packages/tldts-experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tldts-experimental",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "Library to work against complex domain names, subdomains and URIs.",
   "author": "Rémi Berson",
   "contributors": [
@@ -54,14 +54,14 @@
     "rollup": "^1.17.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "tldts-tests": "^5.3.1",
+    "tldts-tests": "^5.3.2",
     "ts-jest": "^24.0.2",
     "tslint": "^5.18.0",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.5.2"
   },
   "dependencies": {
-    "tldts-core": "^5.3.1"
+    "tldts-core": "^5.3.2"
   },
   "keywords": [
     "tld",

--- a/packages/tldts-tests/package.json
+++ b/packages/tldts-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tldts-tests",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "private": true,
   "description": "tests for different tldts implementations",
   "author": "Rémi Berson",

--- a/packages/tldts/package.json
+++ b/packages/tldts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tldts",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "Library to work against complex domain names, subdomains and URIs.",
   "author": "Rémi Berson",
   "contributors": [
@@ -57,14 +57,14 @@
     "rollup": "^1.17.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "tldts-tests": "^5.3.1",
+    "tldts-tests": "^5.3.2",
     "ts-jest": "^24.0.2",
     "tslint": "^5.18.0",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.5.2"
   },
   "dependencies": {
-    "tldts-core": "^5.3.1"
+    "tldts-core": "^5.3.2"
   },
   "keywords": [
     "tld",


### PR DESCRIPTION
- update public suffix ruleset [#207](https://github.com/remusao/tldts/pull/207)
- fix source maps [#207](https://github.com/remusao/tldts/pull/207)
- make sure tslib does not appear in build artifacts [#207](https://github.com/remusao/tldts/pull/207)

Thanks to @osdiab for catching and reporting [the issue](https://github.com/remusao/tldts/issues/206) with `tslib`.