### PR TITLE
fix: handling of ipv6 when 'extractHostname' option is 'false'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 *not released*
 
+### 5.6.1
+
+*2019-10-14*
+
+- Fix detection of IPv6 when `extractHostname` is `false` [#256](https://github.com/remusao/tldts/pull/256)
+  * Allow IPv6 to be specified with or without brackets
+  * Make sure detection is case-insensitive
+
 ### 5.6.0
 
 *2019-10-12*

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "5.6.0"
+  "version": "5.6.1"
 }

--- a/packages/tldts-core/package.json
+++ b/packages/tldts-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tldts-core",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "tldts core primitives (internal module)",
   "author": {
     "name": "Rémi Berson"

--- a/packages/tldts-core/src/is-ip.ts
+++ b/packages/tldts-core/src/is-ip.ts
@@ -36,24 +36,36 @@ function isProbablyIpv4(hostname: string): boolean {
  * Similar to isProbablyIpv4.
  */
 function isProbablyIpv6(hostname: string): boolean {
+  if (hostname.length < 3) {
+    return false;
+  }
+
+  let start = hostname[0] === '[' ? 1 : 0;
+  let end = hostname.length;
+
+  if (hostname[end - 1] === ']') {
+    end -= 1;
+  }
+
   // We only consider the maximum size of a normal IPV6. Note that this will
   // fail on so-called "IPv4 mapped IPv6 addresses" but this is a corner-case
   // and a proper validation library should be used for these.
-  if (hostname.length > 39) {
+  if (end - start > 39) {
     return false;
   }
 
   let hasColon: boolean = false;
 
-  for (let i = 0; i < hostname.length; i += 1) {
-    const code = hostname.charCodeAt(i);
+  for (; start < end; start += 1) {
+    const code = hostname.charCodeAt(start);
 
     if (code === 58 /* ':' */) {
       hasColon = true;
-    } else if (
-      ((code >= 48 && code <= 57) || // 0-9
-        (code >= 97 && code <= 102)) === false // a-f
-    ) {
+    } else if ((
+      (code >= 48 && code <= 57) || // 0-9
+      (code >= 97 && code <= 102) || // a-f
+      (code >= 65 && code <= 90) // A-F
+    ) === false) {
       return false;
     }
   }

--- a/packages/tldts-core/test/tldts.test.ts
+++ b/packages/tldts-core/test/tldts.test.ts
@@ -18,12 +18,12 @@ describe('#isIp', () => {
     expect(isIp('::1')).toEqual(true);
     expect(isIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334')).toEqual(true);
     expect(isIp('192.168.0.1')).toEqual(true);
+    expect(isIp('[::1]')).toEqual(true);
+    expect(isIp('[2001:0db8:85a3:0000:0000:8a2e:0370:7334]')).toEqual(true);
   });
 
   it('should return false on invalid ip addresses', () => {
     expect(isIp('::1-')).toEqual(false);
-    expect(isIp('[::1]')).toEqual(false);
-    expect(isIp('[2001:0db8:85a3:0000:0000:8a2e:0370:7334]')).toEqual(false);
     expect(isIp('192.168.0.1.')).toEqual(false);
     expect(isIp('192.168.0')).toEqual(false);
     expect(isIp('192.168.0.')).toEqual(false);

--- a/packages/tldts-experimental/package.json
+++ b/packages/tldts-experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tldts-experimental",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "Library to work against complex domain names, subdomains and URIs.",
   "author": {
     "name": "Rémi Berson"
@@ -59,14 +59,14 @@
     "rollup": "^1.17.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "tldts-tests": "^5.6.0",
+    "tldts-tests": "^5.6.1",
     "ts-jest": "^24.0.2",
     "tslint": "^5.18.0",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.5.2"
   },
   "dependencies": {
-    "tldts-core": "^5.6.0"
+    "tldts-core": "^5.6.1"
   },
   "keywords": [
     "tld",

--- a/packages/tldts-tests/package.json
+++ b/packages/tldts-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tldts-tests",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "private": true,
   "description": "tests for different tldts implementations",
   "author": {

--- a/packages/tldts-tests/src/tldts-tests.ts
+++ b/packages/tldts-tests/src/tldts-tests.ts
@@ -690,6 +690,34 @@ export default function test(tldts: any): void {
       );
     });
 
+    it('handles ipv6 address when extractHostname is false', () => {
+      const hostname = '1080::8:800:200C:417A';
+      expect(tldts.parse(hostname, { extractHostname: false })).toEqual({
+        domain: null,
+        domainWithoutSuffix: null,
+        hostname,
+        isIcann: null,
+        isIp: true,
+        isPrivate: null,
+        publicSuffix: null,
+        subdomain: null,
+      });
+    });
+
+    it('handles ipv6 address when extractHostname is false (with brackets)', () => {
+      const hostname = '[1080::8:800:200C:417A]';
+      expect(tldts.parse(hostname, { extractHostname: false })).toEqual({
+        domain: null,
+        domainWithoutSuffix: null,
+        hostname,
+        isIcann: null,
+        isIp: true,
+        isPrivate: null,
+        publicSuffix: null,
+        subdomain: null,
+      });
+    });
+
     it('should handle ipv4 addresses properly', () => {
       expect(tldts.parse('http://192.168.0.1/')).toEqual(
         mockResponse('192.168.0.1'),

--- a/packages/tldts/package.json
+++ b/packages/tldts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tldts",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "Library to work against complex domain names, subdomains and URIs.",
   "author": {
     "name": "Rémi Berson"
@@ -62,14 +62,14 @@
     "rollup": "^1.17.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "tldts-tests": "^5.6.0",
+    "tldts-tests": "^5.6.1",
     "ts-jest": "^24.0.2",
     "tslint": "^5.18.0",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.5.2"
   },
   "dependencies": {
-    "tldts-core": "^5.6.0"
+    "tldts-core": "^5.6.1"
   },
   "keywords": [
     "tld",


### PR DESCRIPTION

- Fix detection of IPv6 when `extractHostname` is `false`
  * Allow IPv6 to be specified with or without brackets
  * Make sure detection is case-insensitive