### PR TITLE
Add workflow to automatically update PSL rules

### DIFF
--- a/.github/workflows/psl.yml
+++ b/.github/workflows/psl.yml
@@ -1,0 +1,51 @@
+name: Assets
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  assets:
+    name: Update local assets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use node 13
+        uses: actions/setup-node@v1
+        with:
+          node-version: '13.x'
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn bootstrap
+
+      - name: Fetch latest assets
+        id: fetch
+        run: yarn update
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN_BOT }}
+          commit-message: "Update upstream public suffix list"
+          title: "Update upstream public suffix list"
+          body: "Automated update of upstream public suffix list"
+          reviewers: remusao
+          branch: update-psl
+          labels: "PR: Update PSL :scroll:"
+
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ env.PULL_REQUEST_NUMBER }}"
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pr_number }}"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.6.4-canary.375.3a45539fdb76a0f1a503983d7258e231ef38e106.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install tldts-core@5.6.4-canary.375.3a45539fdb76a0f1a503983d7258e231ef38e106.0
  npm install tldts-experimental@5.6.4-canary.375.3a45539fdb76a0f1a503983d7258e231ef38e106.0
  npm install tldts@5.6.4-canary.375.3a45539fdb76a0f1a503983d7258e231ef38e106.0
  # or 
  yarn add tldts-core@5.6.4-canary.375.3a45539fdb76a0f1a503983d7258e231ef38e106.0
  yarn add tldts-experimental@5.6.4-canary.375.3a45539fdb76a0f1a503983d7258e231ef38e106.0
  yarn add tldts@5.6.4-canary.375.3a45539fdb76a0f1a503983d7258e231ef38e106.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
