### PR TITLE
Fix inconsistent hostname validation in `getHostname` and `parse(url).hostname` when `validateHostname` is enabled

### DIFF
--- a/packages/tldts-core/src/factory.ts
+++ b/packages/tldts-core/src/factory.ts
@@ -109,26 +109,29 @@ export function parseImpl(
     result.hostname = extractHostname(url, false);
   }
 
-  if (step === FLAG.HOSTNAME || result.hostname === null) {
-    return result;
-  }
-
   // Check if `hostname` is a valid ip address
-  if (options.detectIp) {
+  if (options.detectIp && result.hostname !== null) {
     result.isIp = isIp(result.hostname);
     if (result.isIp) {
       return result;
     }
   }
 
-  // Perform optional hostname validation. If hostname is not valid, no need to
-  // go further as there will be no valid domain or sub-domain.
+  // Perform hostname validation if enabled. If hostname is not valid, no need to
+  // go further as there will be no valid domain or sub-domain. This validation
+  // is applied before any early returns to ensure consistent behavior across
+  // all API methods including getHostname().
   if (
     options.validateHostname &&
     options.extractHostname &&
+    result.hostname !== null &&
     !isValidHostname(result.hostname)
   ) {
     result.hostname = null;
+    return result;
+  }
+
+  if (step === FLAG.HOSTNAME || result.hostname === null) {
     return result;
   }
 

--- a/packages/tldts-tests/src/tldts-tests.ts
+++ b/packages/tldts-tests/src/tldts-tests.ts
@@ -475,8 +475,8 @@ export default function test(
 
   describe('#getHostname', () => {
     it('handles space only inputs', () => {
-      expect(tldts.getHostname(' ')).to.equal('');
-      expect(tldts.getHostname('  ')).to.equal('');
+      expect(tldts.getHostname(' ')).to.equal(null);
+      expect(tldts.getHostname('  ')).to.equal(null);
     });
 
     it('handles space corner-cases', () => {
@@ -647,6 +647,21 @@ export default function test(
       expect(tldts.parse(url)).to.deep.equal(
         tldts.parse(url, { mixedInputs: false }),
       );
+    });
+
+    // https://github.com/remusao/tldts/issues/2258
+    it('should be consistent with parse method', () => {
+      const url = '___id___.c.mystat-in.net';
+
+      // With validation ('_' is forbidden at the start of a label)
+      expect(tldts.parse(url).hostname).to.be.null;
+      expect(tldts.getHostname(url)).to.be.null;
+
+      // Without validation
+      expect(tldts.parse(url, { validateHostname: false }).hostname).to.equal(
+        url,
+      );
+      expect(tldts.getHostname(url, { validateHostname: false })).to.equal(url);
     });
   });
 


### PR DESCRIPTION
Resolves #2258

When `validateHostname` is true, `getHostname(url)` and `parse(url).hostname` now consistently return `null` for invalid or whitespace-only hostnames. This is a breaking change if you previously relied on `getHostname` on some invalid URLs or hostnames.

Previously:
```ts
const tldts = require('tldts');

const url = '___id___.c.mystat-in.net';

// **Wrong** because '_' is not allowed to start a label
tldts.getHostname(url); // Output: ___id___.c.mystat-in.net
tldts.getHostname(url, { validateHostname: true }); // Output: ___id___.c.mystat-in.net
tldts.getHostname(url, { validateHostname: false }); // Output: ___id___.c.mystat-in.net

tldts.parse(url).hostname; // Output: null
tldts.parse(url, { validateHostname: false }).hostname; // Output: ___id___.c.mystat-in.net
```

New consistent behavior:
```ts
const tldts = require('tldts');

const url = '___id___.c.mystat-in.net';

// **Correct**: hostname was appropriately validated in both cases
tldts.getHostname(url); // Output: null
tldts.getHostname(url, { validateHostname: true }); // Output: null
tldts.getHostname(url, { validateHostname: false }); // Output: ___id___.c.mystat-in.net

tldts.parse(url).hostname; // Output: null
tldts.parse(url, { validateHostname: false }).hostname; // Output: ___id___.c.mystat-in.net
```