### PR TITLE
correct example for domain.unknown in README.md

### DIFF
--- a/packages/tldts/README.md
+++ b/packages/tldts/README.md
@@ -136,7 +136,7 @@ tldts.parse('gopher://domain.unknown/');
 //   hostname: 'domain.unknown',
 //   isIcann: false,
 //   isIp: false,
-//   isPrivate: true,
+//   isPrivate: false,
 //   publicSuffix: 'unknown',
 //   subdomain: '' }
 


### PR DESCRIPTION
The example for the parse method contains an error.
'gopher://domain.unknown/'
in the example this shows that isPrivate will return true
but in fact it returns false

closes #2400 