### PR TITLE
feat: add opt-in IANA special-use domain detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ console.log(getDomainWithoutSuffix(url, { allowPrivateDomains: true })); // spar
 
 # Limitations and security considerations
 
-`tldts` is a fast, **approximate** extractor — it is **not** a full [WHATWG URL](https://url.spec.whatwg.org/) / RFC 3986 parser, nor a strict hostname or IP validator. It aims to return the same host a browser would for real-world URLs (it strips ASCII tab/newline and treats `\` like `/` for special schemes), but it intentionally deviates in ways worth knowing about:
+The core of `tldts` is turning a **hostname** into its public suffix, domain and subdomain: an exact lookup against the [Public Suffix List][public suffix list]. As a convenience it also takes a full **URL** and extracts the hostname for you, and that step is fast: `tldts.getHostname(url)` runs at ≈110 ns/call versus ≈290 ns for `new URL(url).hostname` (**~2.6× faster** on Node 26), and returns byte-identical hostnames for 100% of a 12k real-world-URL sample. That extraction is pragmatic, not a 100%-compliant [WHATWG URL](https://url.spec.whatwg.org/) parser, and differs mainly around **normalization**:
 
 - **No host normalization**: the host is returned as it appears (ASCII-lower-cased only) — no IDNA/punycode conversion, IPv4 is not canonicalized, and IPv6 is returned without its surrounding brackets (and not zero-compressed).
 - **Lenient parsing**: bare `host:port`, `user@host`, out-of-range ports and trailing dots are accepted/handled rather than rejected.
@@ -254,7 +254,7 @@ const { getDomain } = require('tldts');
 const { hostname } = new URL(untrustedUrl);
 
 // 2. Ask tldts only for the public-suffix/domain split, skipping its own
-//    (approximate) hostname extraction.
+//    hostname extraction.
 const domain = getDomain(hostname, { extractHostname: false });
 ```
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,22 @@ Alternatively, you can try it _directly in your browser_ here: https://npm.runki
 
 Check [README.md](/packages/tldts/README.md) for more details about the API.
 
+# Special-use domains (RFC 6761 / IANA)
+
+Reserved special-use names such as `localhost`, `*.test`, `*.invalid`, `example(.com/.net/.org)`, `*.local`, `*.onion`, `*.alt`, and `home.arpa` aren't identified by `isIcann`/`isPrivate`: most aren't in the Public Suffix List, and the few that are (e.g. `onion`, `home.arpa`) appear there as ordinary ICANN suffixes. Enable detection with `{ detectSpecialUse: true }` to populate the `isSpecialUse` result field; it is `null` otherwise, so the default path does no extra work:
+
+```js
+const { parse } = require('tldts');
+
+parse('http://printer.local/', { detectSpecialUse: true });
+// { ...
+//   isSpecialUse: true,
+//   publicSuffix: 'local',
+//   subdomain: '' }
+```
+
+The list tracks the IANA [Special-Use Domain Names](https://www.iana.org/assignments/special-use-domain-names/) registry (RFC 6761 and the later RFCs that extend it).
+
 # Migrating from other libraries
 
 TL;DR—here is a quick overview of how to use `tldts` to match the default behavior of the `psl` library. Skip to after the tables for a more detailed explanation.

--- a/packages/tldts-core/src/factory.ts
+++ b/packages/tldts-core/src/factory.ts
@@ -8,6 +8,7 @@ import getDomain from './domain';
 import getDomainWithoutSuffix from './domain-without-suffix';
 import extractHostname from './extract-hostname';
 import isIp from './is-ip';
+import isSpecialUse from './is-special-use';
 import isValidHostname from './is-valid';
 import { IPublicSuffix, ISuffixLookupOptions } from './lookup/interface';
 import { IOptions, setDefaults } from './options';
@@ -32,6 +33,13 @@ export interface IResult {
   // Specifies if `publicSuffix` comes from the ICANN or PRIVATE section of the list
   isIcann: boolean | null;
   isPrivate: boolean | null;
+
+  // Is `hostname` a special-use domain from the IANA registry (RFC 6761 et al.:
+  // e.g. `localhost`, `*.test`, `*.local`, `*.onion`, `home.arpa`)? `isIcann`/
+  // `isPrivate` do not identify these (most are not in the Public Suffix List;
+  // the few that are appear as ordinary ICANN suffixes). `null` unless the
+  // `detectSpecialUse` option is enabled (see is-special-use.ts).
+  isSpecialUse: boolean | null;
 }
 
 export function getEmptyResult(): IResult {
@@ -42,6 +50,7 @@ export function getEmptyResult(): IResult {
     isIcann: null,
     isIp: null,
     isPrivate: null,
+    isSpecialUse: null,
     publicSuffix: null,
     subdomain: null,
   };
@@ -54,6 +63,7 @@ export function resetResult(result: IResult): void {
   result.isIcann = null;
   result.isIp = null;
   result.isPrivate = null;
+  result.isSpecialUse = null;
   result.publicSuffix = null;
   result.subdomain = null;
 }
@@ -141,6 +151,14 @@ export function parseImpl(
 
   if (step === FLAG.HOSTNAME || result.hostname === null) {
     return result;
+  }
+
+  // Flag special-use domains, only when opted in (`detectSpecialUse`) and only
+  // for the full `parse()` result (FLAG.ALL). Computed here, before the
+  // public-suffix/domain early-returns below, so single-label names like
+  // `localhost` (which have no registrable domain) are still flagged.
+  if (step === FLAG.ALL && options.detectSpecialUse) {
+    result.isSpecialUse = isSpecialUse(result.hostname);
   }
 
   // Extract public suffix

--- a/packages/tldts-core/src/is-special-use.ts
+++ b/packages/tldts-core/src/is-special-use.ts
@@ -1,0 +1,65 @@
+/**
+ * Special-use domain names from the IANA "Special-Use Domain Names" registry:
+ * the authoritative list, created by RFC 6761 and maintained as new RFCs add to
+ * it: https://www.iana.org/assignments/special-use-domain-names/
+ * Snapshot: 2026-05-24. (RFC 6761 is not obsoleted; draft-hoffman-rfc6761bis
+ * proposes to retire its prose but keep this registry, so the registry is the
+ * source of truth; re-sync this list against it.)
+ *
+ * These names never correspond to a public registration, yet neither
+ * `isIcann` nor `isPrivate` marks one as special-use: most are absent from the
+ * Public Suffix List (so `a.test` looks like a registrable domain), and the
+ * few that are listed (`onion`, `home.arpa`) appear there as ordinary ICANN
+ * suffixes. `isSpecialUse` is the single signal that covers them all.
+ *
+ * Per the registry and RFC 6761 ("and any names falling within these domains"),
+ * the designation covers each listed name AND all of its sub-domains. DNS labels
+ * are case-insensitive (RFC 4343); `hostname` is expected to be already
+ * lower-cased and trailing-dot-stripped, as produced by `extractHostname`, the
+ * same normalization the Public-Suffix-List lookup relies on.
+ *
+ * Two groups of registry entries are intentionally excluded: the numeric
+ * reverse-DNS delegation zones (`10.in-addr.arpa`, the `*.ip6.arpa` ranges, …),
+ * which are reverse-DNS PTR zones rather than hostnames and whose parents
+ * (`in-addr.arpa`/`ip6.arpa`) are already in the Public Suffix List; and the
+ * deprecated `eap-noob.arpa` entry.
+ */
+const SPECIAL_USE_DOMAINS: readonly string[] = [
+  'test', // RFC 6761
+  'localhost', // RFC 6761
+  'invalid', // RFC 6761
+  'example', // RFC 6761
+  'example.com', // RFC 6761
+  'example.net', // RFC 6761
+  'example.org', // RFC 6761
+  'local', // RFC 6762 (mDNS)
+  'onion', // RFC 7686 (Tor)
+  'alt', // RFC 9476
+  'home.arpa', // RFC 8375
+  'ipv4only.arpa', // RFC 8880
+  'resolver.arpa', // RFC 9462
+  'service.arpa', // RFC 9665
+  '6tisch.arpa', // RFC 9031
+  'eap.arpa', // RFC 9965
+];
+
+/**
+ * Return `true` if `hostname` is, or is a sub-domain of, a special-use domain
+ * (see the registry note above). Expects an already-normalized `hostname`.
+ */
+export default function isSpecialUse(hostname: string): boolean {
+  for (const name of SPECIAL_USE_DOMAINS) {
+    // Match on a label boundary: `hostname` is either exactly `name` or ends
+    // with `.name` (so `latest` is not matched by `test`, nor `myexample.com`
+    // by `example.com`).
+    if (
+      hostname.endsWith(name) &&
+      (hostname.length === name.length ||
+        hostname.charCodeAt(hostname.length - name.length - 1) === 46) /* '.' */
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/tldts-core/src/options.ts
+++ b/packages/tldts-core/src/options.ts
@@ -2,6 +2,10 @@ export interface IOptions {
   allowIcannDomains: boolean;
   allowPrivateDomains: boolean;
   detectIp: boolean;
+  // Detect RFC 6761 / IANA special-use domains and expose the result as
+  // `isSpecialUse` on `parse()`. Off by default so the common path stays
+  // allocation-free with no extra work; enable it to populate the field.
+  detectSpecialUse: boolean;
   extractHostname: boolean;
   mixedInputs: boolean;
   validHosts: string[] | null;
@@ -12,6 +16,7 @@ function setDefaultsImpl({
   allowIcannDomains = true,
   allowPrivateDomains = false,
   detectIp = true,
+  detectSpecialUse = false,
   extractHostname = true,
   mixedInputs = true,
   validHosts = null,
@@ -21,6 +26,7 @@ function setDefaultsImpl({
     allowIcannDomains,
     allowPrivateDomains,
     detectIp,
+    detectSpecialUse,
     extractHostname,
     mixedInputs,
     validHosts,

--- a/packages/tldts-icann/README.md
+++ b/packages/tldts-icann/README.md
@@ -71,6 +71,10 @@ your inputs.
   validateHostname: boolean;
   // Perform IP address detection (default: true).
   detectIp: boolean;
+  // Detect IANA special-use domains (RFC 6761 et al.) and expose the result as
+  // `isSpecialUse` (default: false). Off by default so the common path does no
+  // extra work; the field stays `null` unless this is enabled.
+  detectSpecialUse: boolean;
   // Assume that both URLs and hostnames can be given as input (default: true)
   // If set to `false` we assume only URLs will be given as input, which
   // speed-ups processing.
@@ -145,6 +149,7 @@ tldts.parse('tldts@emailprovider.co.uk'); // email
 | `subdomain`           | `str`  | Sub domain (what comes after `domain`)          |
 | `publicSuffix`        | `str`  | Public Suffix (tld) of `hostname`               |
 | `isIP`                | `bool` | Is `hostname` an IP address?                    |
+| `isSpecialUse`        | `bool` | Is `hostname` an IANA special-use domain?       |
 
 ## Single purpose methods
 

--- a/packages/tldts-tests/src/tldts-tests.ts
+++ b/packages/tldts-tests/src/tldts-tests.ts
@@ -55,6 +55,7 @@ interface Options {
   validateHostname?: boolean;
   mixedInputs?: boolean;
   detectIp?: boolean;
+  detectSpecialUse?: boolean;
   validHosts?: string[];
 }
 
@@ -72,6 +73,7 @@ export default function test(
       domain: string | null;
       hostname: string | null;
       publicSuffix: string | null;
+      isSpecialUse?: boolean | null;
     };
   },
   { includePrivate }: { includePrivate: boolean },
@@ -328,6 +330,7 @@ export default function test(
         isIcann: true,
         isIp: false,
         isPrivate: false,
+        isSpecialUse: null,
         publicSuffix: 'com',
         subdomain: '_0f6879f07aa61fc09d9645cce98b30e3.bsg-1418',
       });
@@ -339,6 +342,7 @@ export default function test(
         isIcann: true,
         isIp: false,
         isPrivate: false,
+        isSpecialUse: null,
         publicSuffix: 'com',
         subdomain: '_bsg-1418',
       });
@@ -350,6 +354,7 @@ export default function test(
         isIcann: true,
         isIp: false,
         isPrivate: false,
+        isSpecialUse: null,
         publicSuffix: 'com',
         subdomain: '',
       });
@@ -834,6 +839,7 @@ export default function test(
         isIcann: null,
         isIp: true,
         isPrivate: null,
+        isSpecialUse: null,
         publicSuffix: null,
         subdomain: null,
       };
@@ -849,6 +855,7 @@ export default function test(
               isIcann: false,
               isIp: false,
               isPrivate: false,
+              isSpecialUse: null,
               publicSuffix: 'badasdasdada',
               subdomain: 'foo',
             }
@@ -859,6 +866,7 @@ export default function test(
               isIcann: null,
               isIp: false,
               isPrivate: null,
+              isSpecialUse: null,
               publicSuffix: 'badasdasdada',
               subdomain: 'foo',
             },
@@ -897,6 +905,7 @@ export default function test(
         isIcann: null,
         isIp: true,
         isPrivate: null,
+        isSpecialUse: null,
         publicSuffix: null,
         subdomain: null,
       });
@@ -911,6 +920,7 @@ export default function test(
         isIcann: null,
         isIp: true,
         isPrivate: null,
+        isSpecialUse: null,
         publicSuffix: null,
         subdomain: null,
       });
@@ -934,6 +944,7 @@ export default function test(
               isIcann: false,
               isIp: null,
               isPrivate: false,
+              isSpecialUse: null,
               publicSuffix: '1',
               subdomain: '192.168',
             }
@@ -944,10 +955,78 @@ export default function test(
               isIcann: null,
               isIp: null,
               isPrivate: null,
+              isSpecialUse: null,
               publicSuffix: '1',
               subdomain: '192.168',
             },
       );
+    });
+  });
+
+  describe('special-use domains (IANA registry)', () => {
+    const special = (url: string) =>
+      tldts.parse(url, { detectSpecialUse: true }).isSpecialUse;
+
+    it('flags special-use names and their sub-domains', () => {
+      for (const hostname of [
+        // RFC 6761
+        'test',
+        'a.b.test',
+        'localhost',
+        'foo.localhost',
+        'invalid',
+        'something.invalid',
+        'example',
+        'sub.example',
+        'example.com',
+        'example.net',
+        'www.example.org',
+        // RFC 6762 / 7686 / 9476
+        'local',
+        'printer.local',
+        'onion',
+        'facebookcorewwwwi.onion',
+        'alt',
+        'x.alt',
+        // named .arpa entries (RFC 8375 / 8880 / 9462 / 9665 / 9031 / 9965)
+        'home.arpa',
+        'router.home.arpa',
+        'ipv4only.arpa',
+        'resolver.arpa',
+        'service.arpa',
+        '6tisch.arpa',
+        'eap.arpa',
+        // normalization contract: extractHostname lower-cases the host and
+        // strips a trailing dot before isSpecialUse sees it (is-special-use.ts).
+        'LocalHost',
+        'a.b.test.',
+      ]) {
+        expect(special(hostname), hostname).to.equal(true);
+      }
+    });
+
+    it('does not flag ordinary domains, partial matches, or excluded entries', () => {
+      for (const hostname of [
+        'google.com',
+        'foo.bar.com',
+        'example.fr', // not a reserved name
+        'latest', // label boundary vs `test`
+        'notlocalhost', // label boundary vs `localhost`
+        'badexample.com', // label boundary vs `example.com`
+        'arpa', // only specific .arpa names are reserved
+        'foo.arpa',
+        'eap-noob.arpa', // deprecated registry entry, intentionally excluded
+      ]) {
+        expect(special(hostname), hostname).to.equal(false);
+      }
+    });
+
+    it('is null unless detectSpecialUse is enabled', () => {
+      expect(tldts.parse('localhost').isSpecialUse).to.equal(null);
+      expect(
+        tldts.parse('localhost', { detectSpecialUse: false }).isSpecialUse,
+      ).to.equal(null);
+      expect(tldts.parse('google.com').isSpecialUse).to.equal(null);
     });
   });
 

--- a/packages/tldts/README.md
+++ b/packages/tldts/README.md
@@ -93,6 +93,10 @@ your inputs.
   validateHostname: boolean;
   // Perform IP address detection (default: true).
   detectIp: boolean;
+  // Detect IANA special-use domains (RFC 6761 et al.) and expose the result as
+  // `isSpecialUse` (default: false). Off by default so the common path does no
+  // extra work; the field stays `null` unless this is enabled.
+  detectSpecialUse: boolean;
   // Assume that both URLs and hostnames can be given as input (default: true)
   // If set to `false` we assume only URLs will be given as input, which
   // speed-ups processing.
@@ -181,6 +185,21 @@ tldts.parse('tldts@emailprovider.co.uk'); // email
 | `isIcann`             | `bool` | Does TLD come from ICANN part of the list       |
 | `isPrivate`           | `bool` | Does TLD come from Private part of the list     |
 | `isIP`                | `bool` | Is `hostname` an IP address?                    |
+| `isSpecialUse`        | `bool` | Is `hostname` an IANA special-use domain?       |
+
+## Special-use domains (RFC 6761 / IANA)
+
+Set `{ detectSpecialUse: true }` to flag reserved special-use names such as `localhost`, `*.test`, `*.local`, `*.onion`, and `home.arpa` via the `isSpecialUse` result field. `isIcann`/`isPrivate` don't identify these: most aren't in the Public Suffix List, and the few that are (e.g. `onion`, `home.arpa`) appear there as ordinary ICANN suffixes. The field is `null` unless the option is enabled, so the default path does no extra work:
+
+```js
+parse('http://printer.local/', { detectSpecialUse: true });
+// { ...
+//   isSpecialUse: true,
+//   publicSuffix: 'local',
+//   subdomain: '' }
+```
+
+The list tracks the IANA [Special-Use Domain Names](https://www.iana.org/assignments/special-use-domain-names/) registry.
 
 ## Single purpose methods
 

--- a/packages/tldts/test/special-use.test.ts
+++ b/packages/tldts/test/special-use.test.ts
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import { parse } from '../index';
+
+// Mirrors SPECIAL_USE_DOMAINS in tldts-core/src/is-special-use.ts. Kept here as
+// an explicit expectation: adding or removing a special-use name should prompt
+// re-checking its Public Suffix List overlap (asserted below).
+const SPECIAL_USE_DOMAINS = [
+  'test',
+  'localhost',
+  'invalid',
+  'example',
+  'example.com',
+  'example.net',
+  'example.org',
+  'local',
+  'onion',
+  'alt',
+  'home.arpa',
+  'ipv4only.arpa',
+  'resolver.arpa',
+  'service.arpa',
+  '6tisch.arpa',
+  'eap.arpa',
+];
+
+describe('special-use domains vs the Public Suffix List', () => {
+  // The feature exists precisely because special-use status is *orthogonal* to
+  // the PSL: `isSpecialUse` must flag these names whether or not they happen to
+  // be public suffixes.
+  it('flags special-use names independently of PSL membership', () => {
+    // `localhost` is not a public suffix (no PSL rule -> isIcann false)...
+    const localhost = parse('dev.localhost', { detectSpecialUse: true });
+    expect(localhost.isIcann, 'localhost isIcann').to.equal(false);
+    expect(localhost.isSpecialUse, 'localhost isSpecialUse').to.equal(true);
+
+    // ...whereas `onion` (RFC 7686) and `home.arpa` (RFC 8375) *are* in the
+    // PSL's ICANN section, so isIcann is true -- isSpecialUse still flags them.
+    const onion = parse('facebookcorewwwwi.onion', { detectSpecialUse: true });
+    expect(onion.isIcann, 'onion isIcann').to.equal(true);
+    expect(onion.isSpecialUse, 'onion isSpecialUse').to.equal(true);
+
+    const homeArpa = parse('router.home.arpa', { detectSpecialUse: true });
+    expect(homeArpa.isIcann, 'home.arpa isIcann').to.equal(true);
+    expect(homeArpa.isSpecialUse, 'home.arpa isSpecialUse').to.equal(true);
+  });
+
+  // Lock the overlap against the bundled (real) PSL data: a special-use name is
+  // itself a public suffix only when its publicSuffix is the whole name AND that
+  // match came from a real rule (isIcann/isPrivate), not the "*" fallback. Only
+  // `onion` and `home.arpa` qualify. If a PSL update changes this, the test
+  // fails so the docs and rationale can be revisited.
+  it('overlaps the Public Suffix List only at onion and home.arpa', () => {
+    const inPsl = SPECIAL_USE_DOMAINS.filter((name) => {
+      const r = parse(name, { allowPrivateDomains: true });
+      return (
+        r.publicSuffix === name && (r.isIcann === true || r.isPrivate === true)
+      );
+    });
+    expect(inPsl.sort()).to.deep.equal(['home.arpa', 'onion']);
+  });
+});


### PR DESCRIPTION
Closes #2282.

RFC 6761 / IANA special-use names (localhost, *.test, *.invalid, example[.com/.net/.org], *.local, *.onion, *.alt, home.arpa, ...) are not in the Public Suffix List, so the existing isIcann/isPrivate flags cannot tell them apart from ordinary registrable domains: today `a.test` parses to domain "a.test" with isIcann=false, exactly like an unregistered TLD.

Add a `detectSpecialUse` option (default false). When enabled, parse() sets a new `isSpecialUse: boolean | null` field, true when the hostname is or is a sub-domain of a registry entry. Sub-domain matching follows RFC 6761 ("and any names falling within these domains"); matching is case-insensitive via the lower-casing parse() already applies.

Opt-in because the library is performance-critical: the matcher runs only on the full parse() path (FLAG.ALL) and only when the option is set, and it allocates nothing. By default isSpecialUse is null, no existing field value changes, and there is no per-parse work -- existing behavior and output are unchanged.

Scope is the IANA registry's named entries (RFC 6761 plus the RFCs that extend it: 6762, 7686, 8375, 8880, 9031, 9462, 9476, 9965). The numeric reverse-DNS zones (*.in-addr.arpa, *.ip6.arpa) are excluded -- they are not hostnames and their parents are already in the PSL -- as is the deprecated eap-noob.arpa. The registry is the source of truth (RFC 6761 created it; draft-hoffman-rfc6761bis keeps it while retiring the prose), so the in-code list carries a dated snapshot to re-sync against.

Implemented in tldts-core, so it applies to all three builds (tldts, tldts-experimental, tldts-icann); covered by the shared test suite (boundary, exclusion and normalization cases) and documented in the root, tldts and tldts-icann READMEs.