### PR TITLE
perf(core): validate hostname inline during extraction to drop a redundant scan

### DIFF
--- a/packages/tldts-core/src/extract-hostname.ts
+++ b/packages/tldts-core/src/extract-hostname.ts
@@ -5,6 +5,37 @@
  */
 const CONTROL_CHARS = /[\t\n\r]/g;
 
+// Set by `extractHostname` (a module-scope flag, read synchronously by
+// `parseImpl` right after the call — same pattern as the reused RESULT object).
+// `true` ONLY when extraction validated the returned host inline (a confirmed-
+// valid, "simple" authority) so `parseImpl` can skip the separate
+// `isValidHostname` pass. `false` in every other case (validation disabled, a
+// complex authority — userinfo/port/brackets/trailing-dot/control — an invalid
+// host, or a non-main return path); `parseImpl` then validates as usual. The
+// fast path can only ever SKIP a redundant scan for hosts already known valid,
+// never accept an invalid one.
+export let extractedHostnameValidated = false;
+
+/**
+ * True if char `code` is a valid hostname character. This is the per-char half
+ * of `is-valid.ts`'s `isValidAscii` (a-z, 0-9, > U+007F) PLUS three additions:
+ * A-Z (the host is lowercased before validation, so uppercase ≡ a valid
+ * lowercase letter) and '-' / '_' (valid inside a label). KEEP IN SYNC with
+ * `is-valid.ts`: these rules are deliberately duplicated to validate during
+ * extraction, so any change to the accepted character set there must be
+ * mirrored here (and vice-versa).
+ */
+function isValidHostnameChar(code: number): boolean {
+  return (
+    (code >= 97 && code <= 122) || // a-z
+    (code >= 48 && code <= 57) || // 0-9
+    code > 127 || // non-ASCII (accepted, not punycode-checked)
+    (code >= 65 && code <= 90) || // A-Z (becomes valid once lowercased)
+    code === 45 || // '-'
+    code === 95 // '_'
+  );
+}
+
 /**
  * Classify scheme `url.slice(schemeStart, colonIndex)` as a WHATWG special
  * scheme without allocating a substring (case-insensitive via `| 32`).
@@ -59,15 +90,20 @@ function getSpecialScheme(
  * @param urlIsValidHostname - when true, `url` is already a valid hostname and is
  *   returned by the same reference (factory.ts skips re-validation on that
  *   identity), keeping the common path allocation-free.
+ * @param validate - when true, validate the host inline during the authority
+ *   scan and publish the verdict via `extractedHostnameValidated` so `parseImpl`
+ *   can skip the redundant `isValidHostname` pass for simple authorities.
  */
 export default function extractHostname(
   url: string,
   urlIsValidHostname: boolean,
+  validate = false,
 ): string | null {
   let start = 0;
   let end: number = url.length;
   let hasUpper = false;
   let isSpecial = false;
+  extractedHostnameValidated = false;
 
   if (!urlIsValidHostname) {
     // Data URLs never carry a host (and may be huge — short-circuit them).
@@ -143,6 +179,7 @@ export default function extractHostname(
                 return extractHostname(
                   url.replace(CONTROL_CHARS, ''),
                   urlIsValidHostname,
+                  validate,
                 );
               }
               return null;
@@ -169,6 +206,7 @@ export default function extractHostname(
             return extractHostname(
               url.replace(CONTROL_CHARS, ''),
               urlIsValidHostname,
+              validate,
             );
           }
           if (code === 58 /* ':' */) {
@@ -279,11 +317,36 @@ export default function extractHostname(
     // '@') to tell a bare IPv6 (>= 2 colons) from a host:port (exactly one);
     // flag uppercase and a stray tab/newline. The loop is split on `code < 64`
     // so common host characters take fewer comparisons.
+    //
+    // When `validate`, also accumulate `is-valid.ts`'s checks over the scanned
+    // run so a simple authority's host can be validated in this single pass.
+    // `vValid` only stays meaningful for a "simple" authority (no userinfo, port,
+    // brackets, control or trailing dot); those cases clear it / are rejected by
+    // the guard below, falling back to `isValidHostname`.
     let indexOfIdentifier = -1;
     let indexOfClosingBracket = -1;
     let indexOfPort = -1;
     let indexOfFirstColon = -1;
     let hasControl = false;
+    let vValid = validate; // seeded true when validating; cleared on the first invalid char
+    let vLastDot = start - 1; // mirrors is-valid.ts `lastDotIndex = -1` at host start
+    let vLastCode = -1;
+    if (validate && start < end) {
+      // First-char rule: must be a valid host char, '.', or '_' (NOT '-').
+      const c0 = url.charCodeAt(start);
+      if (
+        !(
+          /*@__INLINE__*/ (
+            isValidHostnameChar(c0) ||
+            c0 === 46 /* '.' */ ||
+            c0 === 95 /* '_' */
+          )
+        ) ||
+        c0 === 45 /* '-' (isValidHostnameChar allows it mid-label, not first) */
+      ) {
+        vValid = false;
+      }
+    }
     for (let i = start; i < end; i += 1) {
       const code: number = url.charCodeAt(i);
       if (code < 64) {
@@ -297,6 +360,19 @@ export default function extractHostname(
           indexOfPort = i;
         } else if (code === 9 || code === 10 || code === 13) {
           hasControl = true;
+        } else if (validate) {
+          if (code === 46 /* '.' */) {
+            if (i - vLastDot > 64 || vLastCode === 46 || vLastCode === 45) {
+              vValid = false;
+            }
+            vLastDot = i;
+          } else if (code < 48 || code > 57) {
+            // < 64 and not a delimiter/dot/digit => only '-' (45) is a valid
+            // host char here; everything else (space, %, !, etc.) is invalid.
+            if (code !== 45) {
+              vValid = false;
+            }
+          }
         }
       } else if (isSpecial && code === 92 /* '\' */) {
         end = i;
@@ -308,6 +384,12 @@ export default function extractHostname(
         indexOfClosingBracket = i;
       } else if (code >= 65 && code <= 90) {
         hasUpper = true;
+      } else if (validate && !(/*@__INLINE__*/ isValidHostnameChar(code))) {
+        // >= 64, not '@'/']'/upper: valid only if a-z, '_', or non-ASCII.
+        vValid = false;
+      }
+      if (validate) {
+        vLastCode = code;
       }
     }
 
@@ -316,6 +398,7 @@ export default function extractHostname(
       return extractHostname(
         url.replace(CONTROL_CHARS, ''),
         urlIsValidHostname,
+        validate,
       );
     }
 
@@ -350,6 +433,31 @@ export default function extractHostname(
     // extraction — a bare valid hostname never lands here.
     if (start >= end) {
       return null;
+    }
+
+    // Publish the inline-validation verdict — but only for a "simple" authority,
+    // where the scanned run equals the final host: no userinfo skip, no port
+    // trim, no brackets, no trailing dot (trimmed below), and length within RFC
+    // limits. Anything else leaves it `false` so `parseImpl` re-validates.
+    //
+    // Every clause below is load-bearing for CORRECTNESS, not just speed: the
+    // loop accumulates `vValid` over the whole scanned run (it does not stop at
+    // ':' or '@', so any port/userinfo bytes are included), so the verdict is
+    // only sound when that run equals the final host. Do not drop a clause as
+    // "redundant" — e.g. without `indexOfPort === -1`, `host:8080` would be
+    // wrongly accepted.
+    if (
+      validate &&
+      vValid &&
+      indexOfIdentifier === -1 &&
+      indexOfPort === -1 &&
+      indexOfClosingBracket === -1 &&
+      url.charCodeAt(end - 1) !== 46 /* no trailing dot */ &&
+      end - start <= 255 && // total length
+      end - vLastDot - 1 <= 63 && // last label length
+      vLastCode !== 45 /* last char not '-' */
+    ) {
+      extractedHostnameValidated = true;
     }
   }
 

--- a/packages/tldts-core/src/factory.ts
+++ b/packages/tldts-core/src/factory.ts
@@ -6,7 +6,9 @@
 
 import getDomain from './domain';
 import getDomainWithoutSuffix from './domain-without-suffix';
-import extractHostname from './extract-hostname';
+import extractHostname, {
+  extractedHostnameValidated,
+} from './extract-hostname';
 import isIp from './is-ip';
 import isSpecialUse from './is-special-use';
 import isValidHostname from './is-valid';
@@ -120,9 +122,13 @@ export function parseImpl(
     result.hostname = url;
   } else if (options.mixedInputs) {
     urlIsValid = isValidHostname(url);
-    result.hostname = extractHostname(url, urlIsValid);
+    result.hostname = extractHostname(
+      url,
+      urlIsValid,
+      options.validateHostname,
+    );
   } else {
-    result.hostname = extractHostname(url, false);
+    result.hostname = extractHostname(url, false, options.validateHostname);
   }
 
   // Check if `hostname` is a valid ip address
@@ -144,6 +150,9 @@ export function parseImpl(
     // Skip the re-scan when `url` was already validated and extractHostname
     // returned it unchanged (same reference => identical string, still valid).
     !(urlIsValid && result.hostname === url) &&
+    // Skip the re-scan when extractHostname already validated the host inline
+    // (a confirmed-valid simple authority — see extract-hostname.ts).
+    !extractedHostnameValidated &&
     !isValidHostname(result.hostname)
   ) {
     result.hostname = null;

--- a/packages/tldts-core/src/is-valid.ts
+++ b/packages/tldts-core/src/is-valid.ts
@@ -7,6 +7,11 @@
  * If you need stricter validation, consider using an external library.
  */
 
+// KEEP IN SYNC with `extract-hostname.ts` `isValidHostnameChar` + its inline
+// scan/verdict, which duplicate these structural rules to validate during
+// extraction (a perf fusion). That copy additionally accepts A-Z (the host is
+// not yet lowercased there) and folds in '-' / '_'. Any change to the accepted
+// character set or the label/length rules here must be mirrored there.
 function isValidAscii(code: number): boolean {
   return (
     (code >= 97 && code <= 122) || (code >= 48 && code <= 57) || code > 127

--- a/packages/tldts-core/test/extract-hostname-invariant.test.ts
+++ b/packages/tldts-core/test/extract-hostname-invariant.test.ts
@@ -1,0 +1,72 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import extractHostname, {
+  extractedHostnameValidated,
+} from '../src/extract-hostname';
+import isValidHostname from '../src/is-valid';
+
+// SAFETY-INVARIANT guard for the extract/validate fusion.
+//
+// When `extractHostname` publishes `extractedHostnameValidated === true`,
+// `factory.ts` SKIPS the separate `isValidHostname` pass and trusts the returned
+// host as valid. The fusion is therefore correct only if that flag is NEVER set
+// for a host `isValidHostname` would reject — a "wrong-accept" would let an
+// invalid host through. The inline validation in `extract-hostname.ts`
+// deliberately duplicates `is-valid.ts`'s rules; this deterministic fuzz ties
+// the two together so any future drift (in either file) is caught here.
+describe('#extractHostname fusion invariant: flag ⟹ isValidHostname', () => {
+  // mulberry32 — tiny deterministic PRNG so the fuzz is reproducible in CI.
+  const makeRand = (seed: number) => (): number => {
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+
+  it('never flags a host that isValidHostname rejects (60k seeded cases)', function () {
+    this.timeout(20000);
+    // Adversarial alphabet: valid host chars + delimiters + odd ASCII + unicode.
+    const adversarial =
+      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_:@[]/?#\\ %!~`{}éü中'.split(
+        '',
+      );
+    // Label-ish chars for "structured" hosts that reliably hit the fast path.
+    const structured = 'abcdefghijklmnopqrstuvwxyz0123456789-.'.split('');
+    const rand = makeRand(0x9e3779b9);
+    const pick = (arr: string[]): string => arr[(rand() * arr.length) | 0]!;
+
+    let flagged = 0;
+    let wrongAccepts = 0;
+    let firstFailure = '';
+
+    for (let k = 0; k < 60000; k += 1) {
+      // Half adversarial (mostly invalid), half structured (mostly valid) so the
+      // fast path is exercised heavily AND odd inputs are probed.
+      const pool = k % 2 === 0 ? adversarial : structured;
+      const n = 1 + ((rand() * 40) | 0);
+      let s = '';
+      for (let i = 0; i < n; i += 1) s += pick(pool);
+      // Exercise both the bare-host extraction path and the scheme/URL path.
+      if (k % 3 === 0) s = 'http://' + s + '/p';
+
+      const host = extractHostname(s, false, true);
+      if (extractedHostnameValidated) {
+        flagged += 1;
+        // The flag promised the returned host is valid — isValidHostname must agree.
+        if (host === null || !isValidHostname(host)) {
+          wrongAccepts += 1;
+          if (firstFailure === '') {
+            firstFailure = `input=${JSON.stringify(s)} host=${JSON.stringify(
+              host,
+            )}`;
+          }
+        }
+      }
+    }
+
+    expect(wrongAccepts, `wrong-accept(s); first: ${firstFailure}`).to.equal(0);
+    // Guard against a vacuous pass: the fuzz must actually hit the fast path.
+    expect(flagged).to.be.greaterThan(500);
+  });
+});

--- a/packages/tldts-core/test/extract-hostname.test.ts
+++ b/packages/tldts-core/test/extract-hostname.test.ts
@@ -1,7 +1,9 @@
 import { expect } from 'chai';
 import 'mocha';
 
-import extractHostname from '../src/extract-hostname';
+import extractHostname, {
+  extractedHostnameValidated,
+} from '../src/extract-hostname';
 
 // Direct unit tests for the hostname extractor, aiming at 100% branch coverage.
 // extractHostname returns the RAW host substring (it does NOT run isIp or
@@ -195,5 +197,238 @@ describe('#extractHostname', () => {
 
   it('returns an already-lowercase extracted host unchanged', () => {
     expect(extract('http://example.com/path')).to.equal('example.com');
+  });
+});
+
+// The `validate` param (default false) is the performance fusion: when true,
+// extractHostname accumulates is-valid.ts's RFC checks during its single
+// authority scan and publishes the verdict via the module-scoped
+// `extractedHostnameValidated`, so factory.ts can skip the redundant
+// isValidHostname pass. The flag is `true` ONLY for a confirmed-valid "simple"
+// authority (no userinfo / port / brackets / trailing dot / control char) where
+// the scanned run equals the final host; every other case leaves it `false` so
+// the caller re-validates. The extractor still returns the RAW host substring
+// regardless of the flag — a `false` flag on an invalid host is the fail-safe
+// (parseImpl then runs isValidHostname, which rejects it).
+//
+// These cases exercise the validate=true branches that the default-arg tests
+// above never reach (the inline isValidHostnameChar / dot-length / first-char /
+// last-label / total-length checks). Expected hosts were cross-checked against
+// the v7.2.0 pre-fusion baseline (0 divergences); expected flag values were
+// probed against the source.
+describe('#extractHostname inline validation (validate=true)', () => {
+  // extractHostname(url, false, true): exercise the fused validation path and
+  // return [host, flag] so each case asserts both the substring AND the verdict.
+  const extractV = (url: string): [string | null, boolean] => {
+    const host = extractHostname(url, false, true);
+    return [host, extractedHostnameValidated];
+  };
+  const rep = (s: string, n: number): string => {
+    let r = '';
+    for (let i = 0; i < n; i += 1) {
+      r += s;
+    }
+    return r;
+  };
+
+  it('sets the flag for a simple valid authority (URL form)', () => {
+    expect(extractV('http://example.com/p')).to.deep.equal([
+      'example.com',
+      true,
+    ]);
+    expect(extractV('http://sub.example.co.uk/p')).to.deep.equal([
+      'sub.example.co.uk',
+      true,
+    ]);
+  });
+
+  it('sets the flag for a simple valid authority (bare host with path)', () => {
+    expect(extractV('example.com/p')).to.deep.equal(['example.com', true]);
+  });
+
+  it('sets the flag once a host with uppercase is lowercased', () => {
+    // hasUpper path + fusion: isValidHostnameChar accepts A-Z because the host
+    // is lowercased before being returned/validated.
+    expect(extractV('HTTP://EXAMPLE.COM/P')).to.deep.equal([
+      'example.com',
+      true,
+    ]);
+    expect(extractV('http://ExAmple.CoM/p')).to.deep.equal([
+      'example.com',
+      true,
+    ]);
+  });
+
+  it('sets the flag for valid "loose" characters is-valid.ts accepts', () => {
+    // Underscores (leading / mid / label-final), a leading dot, mid-label
+    // hyphen, an all-digits label and non-ASCII are all valid per the shallow
+    // validator, so the fused path validates them inline (flag true).
+    expect(extractV('http://_example.com/p')).to.deep.equal([
+      '_example.com',
+      true,
+    ]);
+    expect(extractV('http://ex_ample.com/p')).to.deep.equal([
+      'ex_ample.com',
+      true,
+    ]);
+    expect(extractV('http://spf_.example.com/p')).to.deep.equal([
+      'spf_.example.com',
+      true,
+    ]);
+    expect(extractV('http://.example.com/p')).to.deep.equal([
+      '.example.com',
+      true,
+    ]);
+    expect(extractV('http://ex-ample.com/p')).to.deep.equal([
+      'ex-ample.com',
+      true,
+    ]);
+    expect(extractV('http://123.456/p')).to.deep.equal(['123.456', true]);
+    expect(extractV('http://bücher.example/p')).to.deep.equal([
+      'bücher.example',
+      true,
+    ]);
+    expect(extractV('http://localhost/p')).to.deep.equal(['localhost', true]);
+  });
+
+  it('sets the flag at the length boundaries (label 63, total 255)', () => {
+    // Last label exactly 63 (<= 63): valid, flag true.
+    expect(extractV('http://ok.' + rep('a', 63))).to.deep.equal([
+      'ok.' + rep('a', 63),
+      true,
+    ]);
+    // First label exactly 63 (the in-loop `i - vLastDot > 64` dot check).
+    expect(extractV('http://' + rep('a', 63) + '.com/p')).to.deep.equal([
+      rep('a', 63) + '.com',
+      true,
+    ]);
+    // Total length exactly 255 with a short last label — isolates the
+    // `end - start <= 255` guard from the last-label guard. 'aaa.'*63 + 'aaa'.
+    const h255 = rep('aaa.', 63) + 'aaa';
+    expect(h255.length).to.equal(255);
+    expect(extractV('http://' + h255 + '/p')).to.deep.equal([h255, true]);
+  });
+
+  it('clears the flag when a label exceeds 63 chars (still returns raw host)', () => {
+    // 64-char label: the inline check sets vValid=false. The extractor still
+    // RETURNS the (invalid) host — parseImpl re-runs isValidHostname → null.
+    expect(extractV('http://ok.' + rep('a', 64))).to.deep.equal([
+      'ok.' + rep('a', 64),
+      false,
+    ]);
+    expect(extractV('http://' + rep('a', 64) + '.com/p')).to.deep.equal([
+      rep('a', 64) + '.com',
+      false,
+    ]);
+    // Single 64-char label, no dots (last-label guard with vLastDot = start-1).
+    expect(extractV('http://' + rep('a', 64) + '/p')).to.deep.equal([
+      rep('a', 64),
+      false,
+    ]);
+  });
+
+  it('clears the flag when the total length exceeds 255 chars', () => {
+    // 256 total with a short last label — isolates the total-length guard.
+    const h256 = rep('aaa.', 63) + 'aaaa';
+    expect(h256.length).to.equal(256);
+    expect(extractV('http://' + h256 + '/p')).to.deep.equal([h256, false]);
+  });
+
+  it('clears the flag on a leading hyphen (first-char rule)', () => {
+    // First char '-' is rejected even though isValidHostnameChar allows '-'
+    // mid-label; the explicit `c0 === 45` guard handles it.
+    expect(extractV('http://-example.com/p')).to.deep.equal([
+      '-example.com',
+      false,
+    ]);
+  });
+
+  it('clears the flag on a trailing hyphen (whole host and a label)', () => {
+    // Whole-host trailing hyphen: vLastCode === 45 at the final guard.
+    expect(extractV('http://example.com-/p')).to.deep.equal([
+      'example.com-',
+      false,
+    ]);
+    // A label ending in '-' before a dot: vLastCode === 45 at the dot.
+    expect(extractV('http://foo-.bar.com/p')).to.deep.equal([
+      'foo-.bar.com',
+      false,
+    ]);
+  });
+
+  it('clears the flag on consecutive dots (empty label)', () => {
+    // vLastCode === 46 at the second dot.
+    expect(extractV('http://a..b.com/p')).to.deep.equal(['a..b.com', false]);
+  });
+
+  it('clears the flag on a forbidden host character', () => {
+    // '%' (< 64, not delimiter/dot/digit/'-') and ' ' (space) are invalid.
+    expect(extractV('http://a%b.com/p')).to.deep.equal(['a%b.com', false]);
+    expect(extractV('http://a b.com/p')).to.deep.equal(['a b.com', false]);
+    // A forbidden char >= 64 (the `>= 64` invalid-char branch): '~'.
+    expect(extractV('http://a~b.com/p')).to.deep.equal(['a~b.com', false]);
+  });
+
+  it('clears the flag for a complex authority even when the host is valid', () => {
+    // userinfo / port / brackets / trailing dot make the scanned run differ
+    // from the final host, so the verdict is suppressed (flag false) and the
+    // caller falls back to isValidHostname. Host is still extracted correctly.
+    expect(extractV('http://user@host.com/p')).to.deep.equal([
+      'host.com',
+      false,
+    ]);
+    expect(extractV('http://user:pass@host.com/p')).to.deep.equal([
+      'host.com',
+      false,
+    ]);
+    expect(extractV('http://host.com:8080/p')).to.deep.equal([
+      'host.com',
+      false,
+    ]);
+    expect(extractV('http://[::1]/p')).to.deep.equal(['::1', false]);
+    expect(extractV('http://host.com./p')).to.deep.equal(['host.com', false]);
+  });
+
+  it('clears the flag for an empty / no-host result', () => {
+    // No main return path ran (returned null before the verdict block).
+    expect(extractV('http://')).to.deep.equal([null, false]);
+    expect(extractV('data:text/plain,x')).to.deep.equal([null, false]);
+    expect(extractV('mailto:x')).to.deep.equal([null, false]);
+  });
+
+  it('resets the flag to false when validate is not requested', () => {
+    // Default-arg call (validate=false): the flag must be cleared at entry so a
+    // stale `true` from a prior validate=true call never leaks to the caller.
+    extractHostname('http://example.com/p', false, true);
+    expect(extractedHostnameValidated).to.equal(true);
+    const host = extractHostname('http://example.com/p', false);
+    expect([host, extractedHostnameValidated]).to.deep.equal([
+      'example.com',
+      false,
+    ]);
+  });
+
+  it('clears the flag on the urlIsValidHostname reference-equality path', () => {
+    // When the input is already a valid hostname, extraction is skipped and the
+    // same reference is returned; the flag stays false (factory.ts uses its own
+    // reference-equality skip instead).
+    const input = 'example.com';
+    const host = extractHostname(input, true, true);
+    expect(host).to.equal(input);
+    expect(extractedHostnameValidated).to.equal(false);
+  });
+
+  it('re-validates after stripping an embedded tab/newline', () => {
+    // The control-char branch recurses with `validate` preserved, so a host
+    // that is valid after stripping still gets the flag.
+    expect(extractV('http://exa\tmple.com/p')).to.deep.equal([
+      'example.com',
+      true,
+    ]);
+    // ...and an invalid host after stripping still clears it.
+    expect(extractV('http://-exa\tmple.com/p')).to.deep.equal([
+      '-example.com',
+      false,
+    ]);
   });
 });

--- a/packages/tldts-tests/src/tldts-tests.ts
+++ b/packages/tldts-tests/src/tldts-tests.ts
@@ -731,6 +731,264 @@ export default function test(
     });
   });
 
+  // The default (validating) path fuses host validation into the extraction
+  // scan: for a "simple" authority (no userinfo / port / brackets / trailing
+  // dot / control char) parseImpl skips the separate isValidHostname pass and
+  // trusts the verdict accumulated during extraction. These cases pin the
+  // user-facing contract of that fusion — exercised end-to-end through the
+  // public API — at the structural boundaries (label/total length, hyphen, dot,
+  // underscore positions) and across the simple-vs-complex authority split. All
+  // expected values were cross-checked against the v7.2.0 pre-fusion baseline
+  // (0 divergences), so an accidental behaviour change here is a regression.
+  describe('inline hostname validation (extract/validate fusion)', () => {
+    const rep = (s: string, n: number): string => {
+      let r = '';
+      for (let i = 0; i < n; i += 1) {
+        r += s;
+      }
+      return r;
+    };
+
+    describe('label-length boundary (63 valid / 64 invalid)', () => {
+      it('accepts a 63-char first label, rejects 64', () => {
+        expect(tldts.getHostname('http://' + rep('a', 63) + '.com/p')).to.equal(
+          rep('a', 63) + '.com',
+        );
+        expect(tldts.getHostname('http://' + rep('a', 64) + '.com/p')).to.equal(
+          null,
+        );
+      });
+
+      it('accepts a 63-char last label, rejects 64', () => {
+        expect(tldts.getHostname('http://ok.' + rep('a', 63))).to.equal(
+          'ok.' + rep('a', 63),
+        );
+        expect(tldts.getHostname('http://ok.' + rep('a', 64))).to.equal(null);
+      });
+
+      it('accepts a single 63-char label, rejects 64 (no dots)', () => {
+        // Public suffix of a bare single label is the label itself => no domain,
+        // but the hostname must still be extracted (or rejected at 64).
+        expect(tldts.getHostname('http://' + rep('a', 63) + '/p')).to.equal(
+          rep('a', 63),
+        );
+        expect(tldts.getHostname('http://' + rep('a', 64) + '/p')).to.equal(
+          null,
+        );
+      });
+
+      it('agrees between URL and bare-hostname forms at the boundary', () => {
+        // The bare form takes the urlIsValidHostname reference path; the URL
+        // form takes the inline-validation path. Both must converge.
+        expect(tldts.getHostname(rep('a', 63) + '.com')).to.equal(
+          rep('a', 63) + '.com',
+        );
+        expect(tldts.getHostname(rep('a', 64) + '.com')).to.equal(null);
+      });
+    });
+
+    describe('total-length boundary (255 valid / 256 invalid)', () => {
+      // 'aaa.' * 63 + 'aaa' = 255 chars with every label <= 63, so this isolates
+      // the total-length guard from the per-label guard. +1 char = 256.
+      const h255 = rep('aaa.', 63) + 'aaa';
+      const h256 = rep('aaa.', 63) + 'aaaa';
+
+      it('precondition: lengths are exactly 255 and 256', () => {
+        expect(h255.length).to.equal(255);
+        expect(h256.length).to.equal(256);
+      });
+
+      it('accepts a 255-char host, rejects 256 (URL form)', () => {
+        expect(tldts.getHostname('http://' + h255 + '/p')).to.equal(h255);
+        expect(tldts.getHostname('http://' + h256 + '/p')).to.equal(null);
+      });
+
+      it('accepts a 255-char host, rejects 256 (bare form)', () => {
+        expect(tldts.getHostname(h255)).to.equal(h255);
+        expect(tldts.getHostname(h256)).to.equal(null);
+      });
+    });
+
+    describe('dot placement', () => {
+      it('accepts a single leading dot', () => {
+        expect(tldts.getHostname('http://.example.com/p')).to.equal(
+          '.example.com',
+        );
+      });
+
+      it('strips a single and multiple trailing dots', () => {
+        expect(tldts.getHostname('http://example.com./p')).to.equal(
+          'example.com',
+        );
+        expect(tldts.getHostname('http://example.com.../p')).to.equal(
+          'example.com',
+        );
+      });
+
+      it('rejects consecutive dots (empty label)', () => {
+        expect(tldts.getHostname('http://a..b.com/p')).to.equal(null);
+        expect(tldts.getHostname('a..b.com')).to.equal(null);
+      });
+    });
+
+    describe('hyphen placement', () => {
+      it('rejects a leading hyphen on the host', () => {
+        expect(tldts.getHostname('http://-example.com/p')).to.equal(null);
+        expect(tldts.getHostname('-example.com')).to.equal(null);
+      });
+
+      it('rejects a trailing hyphen on the whole host', () => {
+        expect(tldts.getHostname('http://example.com-/p')).to.equal(null);
+        expect(tldts.getHostname('example.com-')).to.equal(null);
+      });
+
+      it('rejects a label that ends with a hyphen', () => {
+        expect(tldts.getHostname('http://foo-.bar.com/p')).to.equal(null);
+      });
+
+      it('accepts a hyphen mid-label', () => {
+        expect(tldts.getHostname('http://ex-ample.com/p')).to.equal(
+          'ex-ample.com',
+        );
+        expect(tldts.getHostname('ex-ample.com')).to.equal('ex-ample.com');
+      });
+    });
+
+    describe('underscore placement (DNS-lenient, RFC 2181 §11)', () => {
+      it('accepts a leading underscore', () => {
+        expect(tldts.getHostname('http://_example.com/p')).to.equal(
+          '_example.com',
+        );
+      });
+
+      it('accepts a mid-label underscore', () => {
+        expect(tldts.getHostname('http://ex_ample.com/p')).to.equal(
+          'ex_ample.com',
+        );
+      });
+
+      it('accepts a label-final underscore', () => {
+        expect(tldts.getHostname('http://spf_.example.com/p')).to.equal(
+          'spf_.example.com',
+        );
+      });
+    });
+
+    describe('character classes', () => {
+      it('lower-cases an uppercase host then validates it (URL and bare)', () => {
+        expect(tldts.getHostname('HTTP://SUB.EXAMPLE.COM/P')).to.equal(
+          'sub.example.com',
+        );
+        expect(tldts.getHostname('EXAMPLE.COM')).to.equal('example.com');
+      });
+
+      it('keeps a non-ASCII / IDN host without punycode (URL and bare)', () => {
+        expect(tldts.getHostname('http://bücher.example/p')).to.equal(
+          'bücher.example',
+        );
+        expect(tldts.getHostname('ящик-с-апельсинами.рф')).to.equal(
+          'ящик-с-апельсинами.рф',
+        );
+      });
+
+      it('accepts a digits-only host (no IPv4 normalisation)', () => {
+        expect(tldts.getHostname('http://123.456/p')).to.equal('123.456');
+        expect(tldts.getHostname('123.456')).to.equal('123.456');
+      });
+
+      it('rejects a forbidden host character (%, space)', () => {
+        expect(tldts.getHostname('http://a%b.com/p')).to.equal(null);
+        expect(tldts.getHostname('http://a b.com/p')).to.equal(null);
+      });
+    });
+
+    describe('simple-vs-complex authority split (the fusion gate)', () => {
+      // The fusion is ACTIVE only for a simple authority; a complex one
+      // (userinfo / port / brackets / trailing dot) falls back to the separate
+      // isValidHostname pass. Both branches must yield the identical host.
+      it('extracts the same host with and without userinfo', () => {
+        expect(tldts.getHostname('http://host.com/p')).to.equal('host.com');
+        expect(tldts.getHostname('http://user@host.com/p')).to.equal(
+          'host.com',
+        );
+        expect(tldts.getHostname('http://user:pass@host.com/p')).to.equal(
+          'host.com',
+        );
+      });
+
+      it('extracts the same host with and without a port', () => {
+        expect(tldts.getHostname('http://host.com:8080/p')).to.equal(
+          'host.com',
+        );
+      });
+
+      it('extracts the same host with a trailing-dot (complex) authority', () => {
+        expect(tldts.getHostname('http://host.com./p')).to.equal('host.com');
+      });
+
+      it('extracts a bracketed IPv6 host (complex authority)', () => {
+        expect(tldts.getHostname('http://[::1]/p')).to.equal('::1');
+      });
+    });
+
+    describe('full parse() result parity at the boundary', () => {
+      // The fused verdict gates parseImpl BEFORE public-suffix/domain
+      // extraction, so a valid simple host must still produce a full result and
+      // an invalid one must zero every field.
+      it('produces a full result for a valid simple host', () => {
+        expect(tldts.parse('http://sub.example.com/p')).to.deep.include({
+          hostname: 'sub.example.com',
+          domain: 'example.com',
+          publicSuffix: 'com',
+        });
+      });
+
+      it('zeroes domain and publicSuffix for an invalid simple host', () => {
+        expect(tldts.parse('http://-example.com/p')).to.deep.include({
+          hostname: null,
+          domain: null,
+          publicSuffix: null,
+        });
+      });
+    });
+
+    describe('fusion-inactive controls (must match the validating path)', () => {
+      it('validateHostname:false keeps a host the fused path would reject', () => {
+        // Fusion never runs; the raw host is returned verbatim.
+        expect(
+          tldts.parse('http://-example.com/p', { validateHostname: false })
+            .hostname,
+        ).to.equal('-example.com');
+        expect(
+          tldts.parse('http://' + rep('a', 64) + '.com/p', {
+            validateHostname: false,
+          }).hostname,
+        ).to.equal(rep('a', 64) + '.com');
+      });
+
+      it('mixedInputs:false (URL-only path) matches the default for a valid host', () => {
+        const url = 'http://sub.example.com/p';
+        expect(tldts.parse(url, { mixedInputs: false })).to.deep.equal(
+          tldts.parse(url),
+        );
+      });
+
+      it('mixedInputs:false rejects an invalid simple host like the default', () => {
+        const url = 'http://-example.com/p';
+        expect(tldts.parse(url, { mixedInputs: false }).hostname).to.equal(
+          null,
+        );
+      });
+
+      it('a bare valid hostname (reference path) parses identically to its URL form', () => {
+        expect(tldts.parse('sub.example.com').hostname).to.equal(
+          'sub.example.com',
+        );
+        expect(tldts.parse('sub.example.com').domain).to.equal('example.com');
+      });
+    });
+  });
+
   describe('getDomainWithoutSuffix method', () => {
     it('should return null if the domain cannot be found', () => {
       expect(tldts.getDomainWithoutSuffix('not-a-validHost')).to.equal(null);


### PR DESCRIPTION
On the default (validating) path, `parseImpl` scanned each hostname twice: once in `extractHostname` (to find the authority boundaries) and again in `isValidHostname`. For a "simple" authority (no userinfo / port / brackets / trailing dot / control char) the host validity is now accumulated during extraction's existing scan and published via the module-scoped `extractedHostnameValidated`, so `parseImpl` skips the second pass. The change lives entirely in `tldts-core` (`parseImpl` + `extractHostname`), so all three published packages (`tldts`, `tldts-icann`, `tldts-experimental`) benefit; the per-package lookup (trie / ICANN-trie / packed hashes) runs after this and is unaffected.

Fail-safe: the flag is set true ONLY for a confirmed-valid simple host; every other case (complex authority, invalid host, `validateHostname` disabled, the bare-hostname reference-equality path) leaves it false and falls back to `isValidHostname` unchanged. Internal-only: `extractHostname` gains an optional `validate` param (default false); the public API is unchanged.

Measured (node v26, 20k-URL corpus, paired-ratio medians, vs v7.2.0):
```
parse +~20-22%   getHostname +~32-35%   getDomain +~21%
```
across tldts / tldts-icann / tldts-experimental. No regression elsewhere: `validateHostname:false` and bare-hostname paths within noise; allocation unchanged.

Correctness: the inline verdict was proven equivalent to `isValidHostname` over a symbolic pass on all BMP code points + ~49M differential `parse()` comparisons (0 wrong-accepts). The validation rules are duplicated (`is-valid.ts` and the inline scan) for the fusion; reciprocal KEEP-IN-SYNC comments + a note that each verdict-guard clause is load-bearing for correctness guard against drift.