### PR TITLE
fix: reject hostname labels that begin with a hyphen (#2395)

### DIFF
--- a/packages/tldts-core/src/extract-hostname.ts
+++ b/packages/tldts-core/src/extract-hostname.ts
@@ -369,7 +369,10 @@ export default function extractHostname(
           } else if (code < 48 || code > 57) {
             // < 64 and not a delimiter/dot/digit => only '-' (45) is a valid
             // host char here; everything else (space, %, !, etc.) is invalid.
-            if (code !== 45) {
+            // A '-' must also not START a label (the byte right after a '.') —
+            // mirrors is-valid.ts; the first label is covered by the first-char
+            // rule above. (RFC 1034 §3.5 / RFC 1035 §2.3.1 LDH.)
+            if (code !== 45 || vLastCode === 46 /* label-leading '-' */) {
               vValid = false;
             }
           }

--- a/packages/tldts-core/src/is-valid.ts
+++ b/packages/tldts-core/src/is-valid.ts
@@ -64,9 +64,14 @@ export default function (hostname: string): boolean {
 
       lastDotIndex = i;
     } else if (
-      !(/*@__INLINE__*/ (isValidAscii(code) || code === 45 || code === 95))
+      // A forbidden character in the label...
+      !(/*@__INLINE__*/ (isValidAscii(code) || code === 45 || code === 95)) ||
+      // ...or a '-' starting a label (the byte right after a '.'). A label must
+      // not begin with a hyphen (RFC 1034 §3.5 / RFC 1035 §2.3.1 LDH, as amended
+      // by RFC 1123 §2.1; cf. UTS #46 CheckHyphens). The first label is covered by
+      // the leading-character guard above; mirrors the trailing-'-' rule below.
+      (code === 45 && lastCharCode === 46)
     ) {
-      // Check if there is a forbidden character in the label
       return false;
     }
 

--- a/packages/tldts-core/test/extract-hostname.test.ts
+++ b/packages/tldts-core/test/extract-hostname.test.ts
@@ -352,7 +352,10 @@ describe('#extractHostname inline validation (validate=true)', () => {
       'foo.-example.com',
       false,
     ]);
-    expect(extractV('http://a.b.-c.com/p')).to.deep.equal(['a.b.-c.com', false]);
+    expect(extractV('http://a.b.-c.com/p')).to.deep.equal([
+      'a.b.-c.com',
+      false,
+    ]);
     expect(extractV('http://foo.-com/p')).to.deep.equal(['foo.-com', false]);
     // A hyphen NOT at a label start stays valid (flag stays true).
     expect(extractV('http://foo.ex-ample.com/p')).to.deep.equal([

--- a/packages/tldts-core/test/extract-hostname.test.ts
+++ b/packages/tldts-core/test/extract-hostname.test.ts
@@ -343,6 +343,24 @@ describe('#extractHostname inline validation (validate=true)', () => {
     ]);
   });
 
+  it('clears the flag on a label-leading hyphen (interior / final label)', () => {
+    // A '-' right after a '.' starts a label — invalid (RFC 1034 §3.5 LDH), the
+    // `vLastCode === 46` arm. The first-char rule above only covers the FIRST
+    // label; these interior/final cases use the in-loop check. @see issue #2395.
+    // The extractor still RETURNS the raw host; parseImpl re-validates → null.
+    expect(extractV('http://foo.-example.com/p')).to.deep.equal([
+      'foo.-example.com',
+      false,
+    ]);
+    expect(extractV('http://a.b.-c.com/p')).to.deep.equal(['a.b.-c.com', false]);
+    expect(extractV('http://foo.-com/p')).to.deep.equal(['foo.-com', false]);
+    // A hyphen NOT at a label start stays valid (flag stays true).
+    expect(extractV('http://foo.ex-ample.com/p')).to.deep.equal([
+      'foo.ex-ample.com',
+      true,
+    ]);
+  });
+
   it('clears the flag on a trailing hyphen (whole host and a label)', () => {
     // Whole-host trailing hyphen: vLastCode === 45 at the final guard.
     expect(extractV('http://example.com-/p')).to.deep.equal([

--- a/packages/tldts-core/test/tldts.test.ts
+++ b/packages/tldts-core/test/tldts.test.ts
@@ -112,6 +112,34 @@ describe('#isValidHostname', () => {
     expect(isValidHostname('.com')).to.equal(true);
   });
 
+  it('should reject labels that begin with a hyphen', () => {
+    // A label must not start with '-' (RFC 1034 §3.5 / RFC 1035 §2.3.1 LDH; cf.
+    // UTS #46 CheckHyphens). The first label was already rejected ('-google.com');
+    // these pin the same rule for interior and final labels. @see issue #2395
+    expect(isValidHostname('foo.-example.com')).to.equal(false); // interior label
+    expect(isValidHostname('foo.-com')).to.equal(false); // final label
+    expect(isValidHostname('a.b.-c.com')).to.equal(false); // deeper interior label
+    expect(isValidHostname('.-foo.com')).to.equal(false); // leading dot, then hyphen-label
+    expect(isValidHostname('a.--b.com')).to.equal(false); // label starting with '--'
+    expect(isValidHostname('a.-.b.com')).to.equal(false); // single-'-' label
+
+    // Only the FIRST char of a label decides: '-_' starts with '-' (invalid),
+    // '_-' starts with '_' (valid).
+    expect(isValidHostname('a.-_b.com')).to.equal(false);
+    expect(isValidHostname('a._-b.com')).to.equal(true);
+
+    // Underscore-leading labels (DKIM/DMARC/SRV), leading dots and interior
+    // hyphens stay valid — and the rule must NOT touch punycode/IDN labels,
+    // whose interior '--' is legitimate.
+    expect(isValidHostname('_dmarc.example.com')).to.equal(true);
+    expect(isValidHostname('_sip._tcp.example.com')).to.equal(true);
+    expect(isValidHostname('foo._bar.com')).to.equal(true);
+    expect(isValidHostname('.google.com')).to.equal(true);
+    expect(isValidHostname('foo.ex-ample.com')).to.equal(true);
+    expect(isValidHostname('xn--mnchen-3ya.de')).to.equal(true); // IDN label with '--'
+    expect(isValidHostname('a.xn--p1ai')).to.equal(true); // punycode TLD
+  });
+
   it('should accept extra code points in domain (not strict)', () => {
     // @see https://github.com/oncletom/tld.js/pull/122
     expect(isValidHostname('foo.bar_baz.com')).to.equal(true);

--- a/packages/tldts-tests/src/tldts-tests.ts
+++ b/packages/tldts-tests/src/tldts-tests.ts
@@ -381,8 +381,12 @@ export default function test(
       expect(tldts.getDomain('foo.-example.com')).to.equal(null);
       expect(tldts.getHostname('-example.com')).to.equal(null); // first label (already rejected)
       // Interior hyphens and underscore-leading labels stay valid.
-      expect(tldts.getHostname('foo.ex-ample.com')).to.equal('foo.ex-ample.com');
-      expect(tldts.getHostname('_dmarc.example.com')).to.equal('_dmarc.example.com');
+      expect(tldts.getHostname('foo.ex-ample.com')).to.equal(
+        'foo.ex-ample.com',
+      );
+      expect(tldts.getHostname('_dmarc.example.com')).to.equal(
+        '_dmarc.example.com',
+      );
     });
 
     // @see https://github.com/oncletom/tld.js/issues/53

--- a/packages/tldts-tests/src/tldts-tests.ts
+++ b/packages/tldts-tests/src/tldts-tests.ts
@@ -370,6 +370,21 @@ export default function test(
       expect(tldts.getDomain('s_pf.google.com')).to.equal('google.com'); // middle '_' (reference case)
     });
 
+    // A label must not BEGIN with a hyphen (RFC 1034 §3.5 / RFC 1035 §2.3.1 LDH;
+    // cf. WHATWG "valid domain" / UTS #46 CheckHyphens). validateHostname is on by
+    // default, so an invalid host yields a null parse — exercised here at the
+    // public-API level (the inline-validation fast path). @see issue #2395.
+    it('should reject labels that begin with a hyphen', () => {
+      expect(tldts.getHostname('foo.-example.com')).to.equal(null); // interior label
+      expect(tldts.getHostname('a.b.-c.com')).to.equal(null); // deeper interior label
+      expect(tldts.getHostname('foo.-com')).to.equal(null); // final label
+      expect(tldts.getDomain('foo.-example.com')).to.equal(null);
+      expect(tldts.getHostname('-example.com')).to.equal(null); // first label (already rejected)
+      // Interior hyphens and underscore-leading labels stay valid.
+      expect(tldts.getHostname('foo.ex-ample.com')).to.equal('foo.ex-ample.com');
+      expect(tldts.getHostname('_dmarc.example.com')).to.equal('_dmarc.example.com');
+    });
+
     // @see https://github.com/oncletom/tld.js/issues/53
     it('should correctly extract domain from paths including "@" in the path', () => {
       const domain = tldts.getDomain(


### PR DESCRIPTION
`isValidHostname` rejected a leading '-' only on the first label (`-google.com`) but accepted it on interior/final labels (`foo.-example.com`) — the same malformed label judged differently by position. Now a '-' at the start of any label (the byte after a '.') is rejected, mirroring the existing trailing-'-' rule. This matches RFC 1034 §3.5 / RFC 1035 §2.3.1 LDH (as amended by RFC 1123 §2.1) and WHATWG "valid domain" (UTS #46 CheckHyphens).

Since #2590 the rules are duplicated across two in-sync paths, so the fix lands in both: `is-valid.ts` and the inline fast-path scan in `extract-hostname.ts` (used by `parse`/`getHostname` for simple authorities; the flag => `isValidHostname` fuzz invariant keeps them aligned). Only a '-' at a label start is affected: underscore-leading labels (_dmarc, SRV), leading dots (#1553/#2583), interior hyphens and xn-- IDN labels stay valid.

Resolves https://github.com/remusao/tldts/issues/2395