### PR TITLE
feat: add getFullDomain to return the full hostname incl. subdomain (#2322)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ done.
 const {
   getHostname,
   getDomain,
+  getFullDomain,
   getPublicSuffix,
   getSubdomain,
   getDomainWithoutSuffix,
@@ -231,6 +232,7 @@ const url = 'https://spark-public.s3.amazonaws.com';
 
 console.log(getHostname(url)); // spark-public.s3.amazonaws.com
 console.log(getDomain(url, { allowPrivateDomains: true })); // spark-public.s3.amazonaws.com
+console.log(getFullDomain(url)); // spark-public.s3.amazonaws.com (subdomain + domain, or null if not a registrable domain)
 console.log(getPublicSuffix(url, { allowPrivateDomains: true })); // s3.amazonaws.com
 console.log(getSubdomain(url, { allowPrivateDomains: true })); // ''
 console.log(getDomainWithoutSuffix(url, { allowPrivateDomains: true })); // spark-public

--- a/bench/allocations.js
+++ b/bench/allocations.js
@@ -116,6 +116,7 @@ const VARIANTS = [
 const METHODS = [
   'parse',
   'getDomain',
+  'getFullDomain',
   'getPublicSuffix',
   'getHostname',
   'getSubdomain',

--- a/bench/benchmark.js
+++ b/bench/benchmark.js
@@ -41,6 +41,7 @@ function main() {
       'getHostname',
       'getPublicSuffix',
       'getDomain',
+      'getFullDomain',
       'getSubdomain',
     ]) {
       console.log(`= ${chalk.bold(method)}`);

--- a/packages/tldts-experimental/index.ts
+++ b/packages/tldts-experimental/index.ts
@@ -43,6 +43,18 @@ export function getDomain(
   return parseImpl(url, FLAG.DOMAIN, suffixLookup, options, RESULT).domain;
 }
 
+export function getFullDomain(
+  url: string,
+  options?: Partial<IOptions>,
+): string | null {
+  /*@__INLINE__*/ resetResult(RESULT);
+  const result = parseImpl(url, FLAG.DOMAIN, suffixLookup, options, RESULT);
+  // The hostname *is* the full domain (subdomain + domain) whenever a
+  // registrable domain exists; gate on `domain` so non-registrable inputs
+  // (IPs, suffix-less or invalid hostnames) return `null` like `getDomain`.
+  return result.domain === null ? null : result.hostname;
+}
+
 export function getSubdomain(
   url: string,
   options?: Partial<IOptions>,

--- a/packages/tldts-icann/README.md
+++ b/packages/tldts-icann/README.md
@@ -50,6 +50,7 @@ Alternatively, you can try it _directly in your browser_ here: https://npm.runki
 - `tldts.parse(url | hostname, options)`
 - `tldts.getHostname(url | hostname, options)`
 - `tldts.getDomain(url | hostname, options)`
+- `tldts.getFullDomain(url | hostname, options)`
 - `tldts.getPublicSuffix(url | hostname, options)`
 - `tldts.getSubdomain(url, | hostname, options)`
 - `tldts.getDomainWithoutSuffix(url | hostname, options)`
@@ -188,6 +189,27 @@ getDomain('foo.google.co.uk'); // returns `google.co.uk`
 getDomain('t.co'); // returns `t.co`
 getDomain('fr.t.co'); // returns `t.co`
 getDomain('https://user:password@example.co.uk:8080/some/path?and&query#hash'); // returns `example.co.uk`
+```
+
+### getFullDomain(url | hostname, options?)
+
+Returns the full domain — the subdomain together with the registrable domain (as
+returned by `getDomain(...)`), i.e. the whole hostname _including_ any subdomain —
+or `null` when the input has no registrable domain (IP address, single label,
+bare public suffix, …). The result is the normalized hostname (lower-cased,
+trailing dot stripped); it is not a DNS-absolute name (no trailing root dot) and
+no IDNA/punycode conversion is performed.
+
+```javascript
+const { getFullDomain } = require('tldts-icann');
+
+getFullDomain('google.com'); // returns `google.com`
+getFullDomain('fr.google.com'); // returns `fr.google.com`
+getFullDomain('foo.google.co.uk'); // returns `foo.google.co.uk`
+getFullDomain('t.co'); // returns `t.co`
+getFullDomain('fr.t.co'); // returns `fr.t.co`
+getFullDomain('1.2.3.4'); // returns null (no registrable domain)
+getFullDomain('localhost'); // returns null
 ```
 
 ### getDomainWithoutSuffix(url | hostname, options?)

--- a/packages/tldts-icann/index.ts
+++ b/packages/tldts-icann/index.ts
@@ -43,6 +43,18 @@ export function getDomain(
   return parseImpl(url, FLAG.DOMAIN, suffixLookup, options, RESULT).domain;
 }
 
+export function getFullDomain(
+  url: string,
+  options?: Partial<IOptions>,
+): string | null {
+  /*@__INLINE__*/ resetResult(RESULT);
+  const result = parseImpl(url, FLAG.DOMAIN, suffixLookup, options, RESULT);
+  // The hostname *is* the full domain (subdomain + domain) whenever a
+  // registrable domain exists; gate on `domain` so non-registrable inputs
+  // (IPs, suffix-less or invalid hostnames) return `null` like `getDomain`.
+  return result.domain === null ? null : result.hostname;
+}
+
 export function getSubdomain(
   url: string,
   options?: Partial<IOptions>,

--- a/packages/tldts-tests/src/tldts-tests.ts
+++ b/packages/tldts-tests/src/tldts-tests.ts
@@ -65,6 +65,7 @@ export default function test(
     getPublicSuffix: (url: string, options?: Options) => string | null;
     getHostname: (url: string, options?: Options) => string | null;
     getDomain: (url: string, options?: Options) => string | null;
+    getFullDomain: (url: string, options?: Options) => string | null;
     getSubdomain: (url: string, options?: Options) => string | null;
     parse: (
       url: string,
@@ -412,6 +413,134 @@ export default function test(
       expect(tldts.getDomain('https://www.google.co.uk./maps')).to.equal(
         'google.co.uk',
       );
+    });
+  });
+
+  describe('#getFullDomain', () => {
+    it('returns the full hostname (subdomain + domain) for a registrable domain', () => {
+      expect(tldts.getFullDomain('foo.bar.example.co.uk')).to.equal(
+        'foo.bar.example.co.uk',
+      );
+      expect(
+        tldts.getFullDomain('https://foo.bar.example.co.uk:8080/path?q=1'),
+      ).to.equal('foo.bar.example.co.uk');
+    });
+
+    it('equals the domain when there is no subdomain', () => {
+      expect(tldts.getFullDomain('example.com')).to.equal('example.com');
+    });
+
+    it('normalises like the other extractors (lowercase, trailing dot, userinfo/port)', () => {
+      expect(tldts.getFullDomain('FOO.Example.COM.')).to.equal(
+        'foo.example.com',
+      );
+      expect(tldts.getFullDomain('https://user@a.b.example.com:443/')).to.equal(
+        'a.b.example.com',
+      );
+    });
+
+    it('returns null when there is no registrable domain', () => {
+      expect(tldts.getFullDomain('1.2.3.4')).to.equal(null); // IP
+      expect(tldts.getFullDomain('localhost')).to.equal(null); // single label
+      expect(tldts.getFullDomain('co.uk')).to.equal(null); // public suffix only
+    });
+
+    it('keeps subdomains that are not valid hostnames (#2322 DNS-record use case)', () => {
+      expect(
+        tldts.getFullDomain('___sip___._tcp.sipdbw06.rcs01.5gm.example.com'),
+      ).to.equal('___sip___._tcp.sipdbw06.rcs01.5gm.example.com');
+    });
+
+    it('validateHostname:false skips character checks but still requires a public suffix', () => {
+      // '!' is rejected by the default hostname validation...
+      expect(tldts.getFullDomain('a!b.example.com')).to.equal(null);
+      // ...but the registrable domain is still found when validation is off.
+      expect(
+        tldts.getFullDomain('a!b.example.com', { validateHostname: false }),
+      ).to.equal('a!b.example.com');
+      // A bare label has no registrable domain either way.
+      expect(
+        tldts.getFullDomain('foo_bar', { validateHostname: false }),
+      ).to.equal(null);
+    });
+
+    it('is consistent with getHostname gated on getDomain', () => {
+      for (const input of [
+        'foo.bar.example.co.uk',
+        'https://a.b.c.example.com:8080/p',
+        'example.com',
+        '1.2.3.4',
+        'localhost',
+        'co.uk',
+      ]) {
+        const expected =
+          tldts.getDomain(input) === null ? null : tldts.getHostname(input);
+        expect(tldts.getFullDomain(input)).to.equal(expected);
+      }
+    });
+
+    it('avoids the getSubdomain + getDomain join footgun', () => {
+      // The naive `getSubdomain(x) + '.' + getDomain(x)` recipe emits a spurious
+      // leading dot when there is no subdomain; getFullDomain does not.
+      expect(tldts.getFullDomain('example.com')).to.equal('example.com');
+      expect(
+        `${tldts.getSubdomain('example.com')}.${tldts.getDomain('example.com')}`,
+      ).to.equal('.example.com'); // the footgun, shown for contrast
+    });
+
+    it('honors the validHosts option', () => {
+      expect(
+        tldts.getFullDomain('vhost.intranet', { validHosts: ['intranet'] }),
+      ).to.equal('vhost.intranet');
+      expect(
+        tldts.getFullDomain('intranet', { validHosts: ['intranet'] }),
+      ).to.equal('intranet');
+      // Without it, a bare unknown single label has no registrable domain.
+      expect(tldts.getFullDomain('intranet')).to.equal(null);
+    });
+
+    it('honors allowPrivateDomains (private-suffix gating)', () => {
+      // github.io is in the PRIVATE section: by default it is a registrable
+      // domain in every build.
+      expect(tldts.getFullDomain('github.io')).to.equal('github.io');
+      // Once private suffixes count it becomes a bare suffix (=> null). Only
+      // meaningful for builds that ship the PRIVATE section (not tldts-icann).
+      if (includePrivate) {
+        expect(
+          tldts.getFullDomain('github.io', { allowPrivateDomains: true }),
+        ).to.equal(null);
+        expect(
+          tldts.getFullDomain('user.github.io', { allowPrivateDomains: true }),
+        ).to.equal('user.github.io');
+      }
+    });
+
+    it('handles wildcard and exception public-suffix rules', () => {
+      expect(tldts.getFullDomain('foo.bar.ck')).to.equal('foo.bar.ck'); // *.ck
+      expect(tldts.getFullDomain('foo.ck')).to.equal(null); // bare *.ck suffix
+      expect(tldts.getFullDomain('a.www.ck')).to.equal('a.www.ck'); // !www.ck
+    });
+
+    it('preserves IDN / punycode labels without conversion', () => {
+      expect(tldts.getFullDomain('a.münchen.de')).to.equal('a.münchen.de');
+      expect(tldts.getFullDomain('a.xn--mnchen-3ya.de')).to.equal(
+        'a.xn--mnchen-3ya.de',
+      );
+    });
+
+    it('returns null for IP addresses (no registrable domain)', () => {
+      expect(tldts.getFullDomain('http://[2a01:e35::1]:443/x')).to.equal(null);
+      expect(tldts.getFullDomain('2a01:e35::1')).to.equal(null);
+    });
+
+    it('respects the 255-character hostname length limit', () => {
+      const label = 'a'.repeat(63);
+      const max = `${label}.${label}.${label}.${'a'.repeat(59)}.com`;
+      expect(max).to.have.lengthOf(255);
+      expect(tldts.getFullDomain(max)).to.equal(max);
+      const tooLong = `${label}.${label}.${label}.${'a'.repeat(60)}.com`;
+      expect(tooLong).to.have.lengthOf(256);
+      expect(tldts.getFullDomain(tooLong)).to.equal(null);
     });
   });
 
@@ -1722,6 +1851,7 @@ export default function test(
       expect(tldts.parse(url)).to.deep.equal(tldts.parse(url, {}));
       expect(tldts.getHostname(url)).to.equal(tldts.getHostname(url, {}));
       expect(tldts.getDomain(url)).to.equal(tldts.getDomain(url, {}));
+      expect(tldts.getFullDomain(url)).to.equal(tldts.getFullDomain(url, {}));
       expect(tldts.getPublicSuffix(url)).to.equal(
         tldts.getPublicSuffix(url, {}),
       );

--- a/packages/tldts/README.md
+++ b/packages/tldts/README.md
@@ -68,6 +68,7 @@ Alternatively, you can try it _directly in your browser_ here: https://npm.runki
 - `tldts.parse(url | hostname, options)`
 - `tldts.getHostname(url | hostname, options)`
 - `tldts.getDomain(url | hostname, options)`
+- `tldts.getFullDomain(url | hostname, options)`
 - `tldts.getPublicSuffix(url | hostname, options)`
 - `tldts.getSubdomain(url, | hostname, options)`
 - `tldts.getDomainWithoutSuffix(url | hostname, options)`
@@ -238,6 +239,27 @@ getDomain('foo.google.co.uk'); // returns `google.co.uk`
 getDomain('t.co'); // returns `t.co`
 getDomain('fr.t.co'); // returns `t.co`
 getDomain('https://user:password@example.co.uk:8080/some/path?and&query#hash'); // returns `example.co.uk`
+```
+
+### getFullDomain(url | hostname, options?)
+
+Returns the full domain — the subdomain together with the registrable domain (as
+returned by `getDomain(...)`), i.e. the whole hostname _including_ any subdomain —
+or `null` when the input has no registrable domain (IP address, single label,
+bare public suffix, …). The result is the normalized hostname (lower-cased,
+trailing dot stripped); it is not a DNS-absolute name (no trailing root dot) and
+no IDNA/punycode conversion is performed.
+
+```javascript
+const { getFullDomain } = require('tldts');
+
+getFullDomain('google.com'); // returns `google.com`
+getFullDomain('fr.google.com'); // returns `fr.google.com`
+getFullDomain('foo.google.co.uk'); // returns `foo.google.co.uk`
+getFullDomain('t.co'); // returns `t.co`
+getFullDomain('fr.t.co'); // returns `fr.t.co`
+getFullDomain('1.2.3.4'); // returns null (no registrable domain)
+getFullDomain('localhost'); // returns null
 ```
 
 ### getDomainWithoutSuffix(url | hostname, options?)

--- a/packages/tldts/index.ts
+++ b/packages/tldts/index.ts
@@ -43,6 +43,18 @@ export function getDomain(
   return parseImpl(url, FLAG.DOMAIN, suffixLookup, options, RESULT).domain;
 }
 
+export function getFullDomain(
+  url: string,
+  options?: Partial<IOptions>,
+): string | null {
+  /*@__INLINE__*/ resetResult(RESULT);
+  const result = parseImpl(url, FLAG.DOMAIN, suffixLookup, options, RESULT);
+  // The hostname *is* the full domain (subdomain + domain) whenever a
+  // registrable domain exists; gate on `domain` so non-registrable inputs
+  // (IPs, suffix-less or invalid hostnames) return `null` like `getDomain`.
+  return result.domain === null ? null : result.hostname;
+}
+
 export function getSubdomain(
   url: string,
   options?: Partial<IOptions>,


### PR DESCRIPTION
`getDomain` returns only the registrable (apex) domain. Recovering the whole hostname (subdomain + domain) previously meant `getSubdomain() + '.' + getDomain()` -- which parses twice and is buggy (leading dot when there is no subdomain, "null.null" when there is no domain) -- or reading `parse().hostname` gated on domain, which allocates a result object per call. Two users hit the former in #2322.

`getFullDomain` parses once to FLAG.DOMAIN and returns hostname gated on a non-null domain. No new parsing logic is needed: by construction the subdomain is the hostname minus its domain suffix, so `subdomain + '.' + domain === hostname` whenever a registrable domain exists. Inputs without one (IPs, single labels, bare public suffixes) return null, matching `getDomain`, and unlike `getHostname`, which keeps them.

Like the other single-value getters it reuses the shared RESULT and returns a primitive, so allocation is identical to getDomain (~3x less than parse), speed is on par, and it inherits the v7.3.0 inline-validation fast path. Added to all three entrypoints; purely additive. Named `getFullDomain` rather than getFqdn because the result strips the trailing root dot and does no resolution, so it is not an absolute/fully-qualified name (RFC 8499).